### PR TITLE
Use password for root user when creating additional users or database…

### DIFF
--- a/alpine/mariadb/startup.sh
+++ b/alpine/mariadb/startup.sh
@@ -73,8 +73,8 @@ EOF
 
 	for f in /docker-entrypoint-initdb.d/*; do
 		case "$f" in
-			*.sql)    echo "$0: running $f"; /usr/bin/mysqld --user=mysql --bootstrap --verbose=0 --skip-name-resolve --skip-networking=0 < "$f"; echo ;;
-			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | /usr/bin/mysqld --user=mysql --bootstrap --verbose=0 --skip-name-resolve --skip-networking=0 < "$f"; echo ;;
+			*.sql)    echo "$0: running $f"; /usr/bin/mysqld --user=root -p'$MYSQL_PASSWORD' --verbose=0 --skip-name-resolve --skip-networking=0 < "$f"; echo ;;
+			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | /usr/bin/mysqld --user=root -p'$MYSQL_PASSWORD' --verbose=0 --skip-name-resolve --skip-networking=0 < "$f"; echo ;;
 			*)        echo "$0: ignoring or entrypoint initdb empty $f" ;;
 		esac
 		echo


### PR DESCRIPTION
Use password for root user when creating additional users or databases and remove --bootstrap cli parameter.
We cannot use `--bootstrap` because implies `--skip-grant-option` hence no new users could be created.